### PR TITLE
Add dynamic course routes

### DIFF
--- a/RUTAS_ROL_ESTUDIANTE.md
+++ b/RUTAS_ROL_ESTUDIANTE.md
@@ -1,0 +1,34 @@
+# 🛣️ Sistema de Rutas - Rol de Estudiante
+
+Este archivo resume las rutas disponibles para los estudiantes. Se sigue la misma estructura que el sistema de rutas para maestros.
+
+## 📁 Archivos Relevantes
+```
+frontend/src/routers/
+├── private.tsx            # Rutas protegidas para usuarios autenticados
+├── CourseRouter.tsx       # Selector de curso dinámico
+└── StudentRoutes.tsx      # (en construcción)
+```
+
+---
+
+## 🚀 Rutas Principales
+
+| Ruta | Descripción |
+| ---- | ----------- |
+| `/home` | Página principal del estudiante |
+| `/courses/:courseSlug` | Página de inicio de un curso específico. Ejemplos: `/courses/word`, `/courses/excel` |
+| `/contentPage` | Vista de contenido de la lección actual |
+| `/evaluationPage` | Evaluación de la lección actual |
+| `/comments/:courseId` | Comentarios del curso |
+| `/help` | Página de ayuda |
+
+Las rutas de cursos utilizan un parámetro dinámico `courseSlug` que permite agregar nuevos cursos sin modificar la configuración de rutas.
+
+---
+
+## 🔄 Flujo de Navegación
+1. El estudiante accede a `/home` y selecciona un curso.
+2. Se navega a `/courses/<nombre>` donde `CourseRouter` decide qué componente mostrar.
+3. Desde allí se cargan lecciones, contenidos y evaluaciones de forma dinámica.
+

--- a/frontend/src/modules/student/pages/StudentPage.tsx
+++ b/frontend/src/modules/student/pages/StudentPage.tsx
@@ -39,7 +39,7 @@ export default function StudentPage() {
               {/* Agg una etiqueta bolteada que diga en progreso o completad */}
               {progressLessons.map((progress)=>(
                 <>
-                  <p key={progress.id_course} onClick={()=>handleClickCourseProgress(progress.id_course,`/${progress.name_course}`)} className={`progress-course-${progress.name_course.toLowerCase()}`}>{progress.name_course} <span className="number-process">{progress.completed_lessons}/{progress.all_lessons}</span><span className="span-status-course" style={{'background':progress.status === 'completed'? '#59A9FF':'#FF7659'}}>{progress.status === 'completed'? 'Completo':'En progreso'}</span></p>
+                  <p key={progress.id_course} onClick={()=>handleClickCourseProgress(progress.id_course,`/courses/${progress.name_course}`)} className={`progress-course-${progress.name_course.toLowerCase()}`}>{progress.name_course} <span className="number-process">{progress.completed_lessons}/{progress.all_lessons}</span><span className="span-status-course" style={{'background':progress.status === 'completed'? '#59A9FF':'#FF7659'}}>{progress.status === 'completed'? 'Completo':'En progreso'}</span></p>
 
                  
                 

--- a/frontend/src/routers/CourseRouter.tsx
+++ b/frontend/src/routers/CourseRouter.tsx
@@ -1,0 +1,24 @@
+import { useParams } from "react-router-dom";
+import WordHomePage from "../modules/courses/word/WordHomePage";
+import ExcelHomePage from "../modules/courses/excel/ExcelHomePage";
+import PowerPointHomePage from "../modules/courses/powerpoint/PowerPointHomePage";
+
+/**
+ * CourseRouter selecciona la página correcta según el nombre del curso.
+ * Permite añadir nuevos cursos en el futuro utilizando la misma ruta base.
+ */
+export default function CourseRouter() {
+  const { courseSlug } = useParams<{ courseSlug: string }>();
+  const slug = courseSlug?.toLowerCase();
+
+  switch (slug) {
+    case "word":
+      return <WordHomePage />;
+    case "excel":
+      return <ExcelHomePage />;
+    case "powerpoint":
+      return <PowerPointHomePage />;
+    default:
+      return <div>Curso no disponible</div>;
+  }
+}

--- a/frontend/src/routers/private.tsx
+++ b/frontend/src/routers/private.tsx
@@ -6,9 +6,7 @@ import AuthLayout from "../shared/Layouts/AuthLayout";
 import Help from "../pages/Help";
 import PrivateRouters from "./PrivateRouters";
 import { sharedRoutes } from "./SharedRouters";
-import WordHomePage from "../modules/courses/word/WordHomePage";
-import ExcelHomePage from "../modules/courses/excel/ExcelHomePage";
-import PowerPointHomePage from "../modules/courses/powerpoint/PowerPointHomePage";
+import CourseRouter from "./CourseRouter";
 import LandingPage from "../pages/LandingPage";
 import CommentPageWrapper from "../modules/courses/comments/CommentPageWrapper";
 import ContentPage from "../modules/courses/components/ContentPage";
@@ -24,9 +22,7 @@ export default function RoutersPrivates() {
                   <Route path="/home" element={<StudentPage/>}/>
                   <Route path="/help" element={<Help/>}/>
                   {/* Rutas de los cursos */}
-                  <Route path="/word" element={<WordHomePage/>}/>
-                  <Route path="/excel" element={<ExcelHomePage/>}/>
-                  <Route path="/powerPoint" element={<PowerPointHomePage/>}/>
+                  <Route path="/courses/:courseSlug" element={<CourseRouter />} />
                   <Route path="/contentPage" element={<ContentPage/>}/>
                   <Route path="/evaluationPage" element={<EvaluationPage/>}/>
                   


### PR DESCRIPTION
## Summary
- allow navigating to any course via `/courses/:courseSlug`
- add CourseRouter selector component
- route students to dynamic paths from the progress list
- document student routes

## Testing
- `pytest -q` *(fails: pydantic settings missing)*

------
https://chatgpt.com/codex/tasks/task_e_688902a46dec8331b779b17ebc0073de