### PR TITLE
feat: add role-based redirect route

### DIFF
--- a/frontend/src/modules/auth/Hooks/useFormLogin.ts
+++ b/frontend/src/modules/auth/Hooks/useFormLogin.ts
@@ -87,8 +87,8 @@ export default function useFormLogin() {
       // --- Inicializar sesión global: carga rol, datos y notificaciones ---
       await initSession();
 
-      // --- Redirigir a "/", que se encargará de llevar a /student o /teacher según el rol ---
-      handleBtnNavigate("/");
+      // --- Redirigir a "/redirect", que se encargará de llevar a /student o /teacher según el rol ---
+      handleBtnNavigate("/redirect");
 
     } catch (err) {
       toast.error("No se pudo iniciar sesión.");

--- a/frontend/src/routers/PrivateRouters.tsx
+++ b/frontend/src/routers/PrivateRouters.tsx
@@ -5,6 +5,6 @@ import { useUser } from "../modules/auth/Hooks/useAuth"
 export default function PrivateRouters() {
     // Variable del context que me dice si se encuentra logueado o no
     const {isLoggedIn} = useUser()
-    // EN caso de que este logueado renderizar Outlet, en caso de que no renderizar a landing
-    return isLoggedIn ? <Outlet/>: <Navigate to='/landing' replace />
+    // En caso de no estar autenticado, volver a la landing pública
+    return isLoggedIn ? <Outlet/> : <Navigate to='/' replace />
 }

--- a/frontend/src/routers/RoleRedirect.tsx
+++ b/frontend/src/routers/RoleRedirect.tsx
@@ -1,65 +1,30 @@
-/**
- * Redirige automáticamente a los usuarios según su rol.
- */
-
 import { Navigate } from "react-router-dom";
 import { useUser } from "../modules/auth/Hooks/useAuth";
 
-// COMPONENTE PRINCIPAL
-
 /**
- * RoleRedirect - Redirección principal por roles
- *
- * Redirige según el rol del usuario después del login.
+ * Redirige automáticamente según el rol del usuario.
+ * No renderiza contenido visible.
  */
 export default function RoleRedirect() {
-  const { user, role } = useUser();
+  const { user, role, isReady } = useUser();
+
+  // Esperar a que la información del usuario esté lista
+  if (!isReady) return null;
 
   // Usuario no autenticado
   if (!user || !role) {
-    return <Navigate to="/landing" replace />;
+    return <Navigate to="/" replace />;
   }
 
   // Redirección según rol
-  switch (role) {
-    case "teacher":
-      return <Navigate to="/teacher/home-teacher" replace />;
-
-    case "student":
-      return <Navigate to="/student/home-student" replace />;
-
-    default:
-      return <Navigate to="/landing" replace />;
-  }
-}
-
-// ============================================================================
-// REDIRECCIÓN DESDE PÁGINA PRINCIPAL
-// ============================================================================
-
-/**
- * HomeRoleRedirect - Redirección desde página principal
- *
- * Solo redirige si el usuario está logueado.
- * Si no está logueado, permite ver la página normal.
- */
-export function HomeRoleRedirect() {
-  const { user, role } = useUser();
-
-  // Usuario no autenticado - no redirigir
-  if (!user || !role) {
-    return null;
+  if (role === "teacher") {
+    return <Navigate to="/teacher/home-teacher" replace />;
   }
 
-  // Redirección según rol
-  switch (role) {
-    case "teacher":
-      return <Navigate to="/teacher/home-teacher" replace />;
-
-    case "student":
-      return <Navigate to="/student/home-student" replace />;
-
-    default:
-      return null;
+  if (role === "student") {
+    return <Navigate to="/student/home-student" replace />;
   }
+
+  // Rol desconocido
+  return <Navigate to="/" replace />;
 }

--- a/frontend/src/routers/private.tsx
+++ b/frontend/src/routers/private.tsx
@@ -16,7 +16,7 @@ export default function RoutersPrivates() {
         <Route element={<AuthLayout />}>
 
           {/* Redirección inicial según el rol */}
-          <Route path="/" element={<RoleRedirect />} />
+          <Route path="/redirect" element={<RoleRedirect />} />
 
           {/* Rutas protegidas para profesores */}
           <Route element={<TeacherGuard />}>

--- a/frontend/src/routers/public.tsx
+++ b/frontend/src/routers/public.tsx
@@ -14,6 +14,7 @@ export default function RoutersPublic() {
   return (
         <Routes>
             <Route element={<PublicLayout />}>
+                <Route path="/" element={<LandingPage/>}/>
                 <Route path="/landing" element={<LandingPage/>}/>
                 <Route path="/register" element={<LoginAndRegister opcAuth={false} />}/>
                 <Route path="/confirmEmailRegister" element={<ConfirmEmailRegister/>}/>{/* ################## tener en cuenta para backend */}


### PR DESCRIPTION
Se agrega el componente RoleRedirect para redirección automática según el rol (docente, estudiante, etc.).

Se registra una nueva ruta privada /redirect que actúa como punto intermedio tras el login.

Se modifica el flujo de navegación posterior al login para que apunte a /redirect en lugar de /, evitando que usuarios autenticados vean el landing.

Se expone la landing pública en /, y los usuarios no autenticados son redirigidos allí si intentan acceder a rutas protegidas.

Se encapsulan correctamente los TeacherRoutes dentro de TeacherCourseProvider y TeacherGuard.

Se ajustan componentes compartidos como AuthNavbar y Header para adaptarse dinámicamente al contexto del usuario.